### PR TITLE
Remove subpage to support custom domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,8 @@ title: Microsoft Data Science Toolkit
 bio: Microsoft Data Science Toolkit
 description: >- # this means to ignore newlines until "baseurl:" Write an awesome description for your new site here. You can edit this line in _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description.
   The Microsoft Data Science Toolkit provides Data Scientists, Solution Architects and delivery teams, with packaged, vetted and tested delivery accelerators, delivery guidance and product backlogs for common machine learning scenarios.
-baseurl: "/dstoolkit-web" # the subpath of your site, e.g. /blog
+# baseurl: "/dstoolkit-web" # the subpath of your site, e.g. /blog
+baseurl: ""
 url: "https://microsoft.github.io" # the base hostname & protocol for your site, e.g. http://example.com - Public Repo URL Updated 7.5.2022 WA
 
 # Build settings

--- a/scripts/script-setsingleacceleratorpagecontents.js
+++ b/scripts/script-setsingleacceleratorpagecontents.js
@@ -127,7 +127,8 @@ if (toHide_RelatedAccelerators == false) {
         } else {
             displayName = link;
         }
-        var bigLink = "/dstoolkit-web" + link;
+        // var bigLink = "/dstoolkit-web" + link;
+        var bigLink = link;
         htmlRelatedAccelerators +=
             `<div class="d-grid">
                 <a href="`+ bigLink + `" class="btn btn-primary" style="text-decoration:none;">` + displayName + `</a>


### PR DESCRIPTION
Support for custom domain (ds-toolkit.com).
Remove subpage from related accelerator link in script file.